### PR TITLE
Fix assertion on number of output messages

### DIFF
--- a/jupyter_kernel_test/__init__.py
+++ b/jupyter_kernel_test/__init__.py
@@ -85,7 +85,7 @@ class KernelTests(TestCase):
 
         self.assertEqual(reply['content']['status'], 'ok')
 
-        self.assertEqual(len(output_msgs), 1)
+        self.assertGreaterEqual(len(output_msgs), 1)
         self.assertEqual(output_msgs[0]['msg_type'], 'stream')
         self.assertEqual(output_msgs[0]['content']['name'], 'stdout')
         self.assertIn('hello, world', output_msgs[0]['content']['text'])


### PR DESCRIPTION
There is set of programming languages (eg. Erlang, Elixir), where every expression returns something. Print function can print something to the standard output and besides that, it can also return some value. This is the reason why fixed assertion should also allow 2 messages.
