### PR TITLE
Allow the kernel to shut down gracefully

### DIFF
--- a/jupyter_kernel_test/__init__.py
+++ b/jupyter_kernel_test/__init__.py
@@ -24,7 +24,7 @@ class KernelTests(TestCase):
     @classmethod
     def tearDownClass(cls):
         cls.kc.stop_channels()
-        cls.km.shutdown_kernel(now=True)
+        cls.km.shutdown_kernel()
 
     def flush_channels(self):
         for channel in (self.kc.shell_channel, self.kc.iopub_channel):


### PR DESCRIPTION
I was testing `scilab_kernel`, and leaving open Scilab sessions behind, because `do_shutdown` was never being called.  This patch allows the kernel to shut down gracefully.
