### PR TITLE
More tests

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,6 +29,9 @@ Use it like this:
         # Code in the kernel's language to write "hello, world" to stdout
         code_hello_world = "print 'hello, world'"
 
+        # code which should print something to stderr
+        code_stderr = "import sys; print('test', file=sys.stderr)"
+
         # Tab completions: in each dictionary, text is the input, which it will
         # try to complete from the end of. matches is the collection of results
         # it should expect.

--- a/README.rst
+++ b/README.rst
@@ -20,6 +20,10 @@ Use it like this:
         # language_info.name in a kernel_info_reply should match this
         language_name = "dg"
 
+        # language_info.file_extension, should match kernel_info_reply
+        # (and start with a dot)
+        file_extension = ".py"
+
         # Optional --------------------------------------
 
         # Code in the kernel's language to write "hello, world" to stdout

--- a/README.rst
+++ b/README.rst
@@ -73,10 +73,13 @@ Use it like this:
         supported_history_operations = ("tail", "range", "search")
         code_history_pattern = "1?2*"
 
-
         # A statement/object to which the kernel should respond with some
         # information when inspected
         code_inspect_sample = "zip"
+
+        # Code which should cause the kernel to send a clear_output request
+        # to the frontend
+        code_clear_output = "clear_output()"
 
     if __name__ == '__main__':
         unittest.main()

--- a/README.rst
+++ b/README.rst
@@ -63,9 +63,13 @@ Use it like this:
             {'code': "display(Math('\\frac{1}{2}'))", 'mime': "text/latex"}
         ]
 
-        # A sample history pattern (using ? and * globbing), which should
-        # match at least one 'code' sample in code_execute_result
+        # Which types of history access should be tested (omit this attribute
+        # or use an empty list to test nothing). For history searching,
+        # code_history_pattern should be a glob-type match for one of the
+        # code strings in code_execute_result
+        supported_history_operations = ("tail", "range", "search")
         code_history_pattern = "1?2*"
+
 
         # A statement/object to which the kernel should respond with some
         # information when inspected

--- a/README.rst
+++ b/README.rst
@@ -49,7 +49,7 @@ Use it like this:
         # Samples of code which generate a result value (ie, some text
         # displayed as Out[n])
         code_execute_result = [
-            {'code': "1+1", 'result': "2"}
+            {'code': "1+2+3", 'result': "6"}
         ]
 
         # Samples of code which should generate a rich display output, and
@@ -58,6 +58,14 @@ Use it like this:
             {'code': "display(HTML('<b>test</b>'))", 'mime': "text/html"},
             {'code': "display(Math('\\frac{1}{2}'))", 'mime': "text/latex"}
         ]
+
+        # A sample history pattern (using ? and * globbing), which should
+        # match at least one 'code' sample in code_execute_result
+        code_history_pattern = "1?2*"
+
+        # A statement/object to which the kernel should respond with some
+        # information when inspected
+        code_inspect_sample = "zip"
 
     if __name__ == '__main__':
         unittest.main()

--- a/jupyter_kernel_test/__init__.py
+++ b/jupyter_kernel_test/__init__.py
@@ -105,12 +105,13 @@ class KernelTests(TestCase):
             raise SkipTest
 
         for sample in self.completion_samples:
-            msg_id = self.kc.complete(sample['text'])
-            reply = self.kc.get_shell_msg()
-            validate_message(reply, 'complete_reply', msg_id)
-            if 'matches' in sample:
-                self.assertEqual(set(reply['content']['matches']),
-                                 set(sample['matches']))
+            with self.subTest(text=sample['text']):
+                msg_id = self.kc.complete(sample['text'])
+                reply = self.kc.get_shell_msg()
+                validate_message(reply, 'complete_reply', msg_id)
+                if 'matches' in sample:
+                    self.assertEqual(set(reply['content']['matches']),
+                                     set(sample['matches']))
 
     complete_code_samples = []
     incomplete_code_samples = []
@@ -133,14 +134,17 @@ class KernelTests(TestCase):
 
         self.flush_channels()
 
-        for sample in self.complete_code_samples:
-            self.check_is_complete(sample, 'complete')
+        with self.subTest(status="complete"):
+            for sample in self.complete_code_samples:
+                self.check_is_complete(sample, 'complete')
 
-        for sample in self.incomplete_code_samples:
-            self.check_is_complete(sample, 'incomplete')
+        with self.subTest(status="incomplete"):
+            for sample in self.incomplete_code_samples:
+                self.check_is_complete(sample, 'incomplete')
 
-        for sample in self.invalid_code_samples:
-            self.check_is_complete(sample, 'invalid')
+        with self.subTest(status="invalid"):
+            for sample in self.invalid_code_samples:
+                self.check_is_complete(sample, 'invalid')
 
     code_page_something = ""
 
@@ -178,17 +182,18 @@ class KernelTests(TestCase):
             raise SkipTest
 
         for sample in self.code_execute_result:
-            self.flush_channels()
+            with self.subTest(code=sample['code']):
+                self.flush_channels()
 
-            reply, output_msgs = self.execute_helper(sample['code'])
+                reply, output_msgs = self.execute_helper(sample['code'])
 
-            self.assertEqual(reply['content']['status'], 'ok')
+                self.assertEqual(reply['content']['status'], 'ok')
 
-            self.assertGreaterEqual(len(output_msgs), 1)
-            self.assertEqual(output_msgs[0]['msg_type'], 'execute_result')
-            self.assertIn('text/plain', output_msgs[0]['content']['data'])
-            self.assertEqual(output_msgs[0]['content']['data']['text/plain'],
-                             sample['result'])
+                self.assertGreaterEqual(len(output_msgs), 1)
+                self.assertEqual(output_msgs[0]['msg_type'], 'execute_result')
+                self.assertIn('text/plain', output_msgs[0]['content']['data'])
+                self.assertEqual(output_msgs[0]['content']['data']['text/plain'],
+                                 sample['result'])
 
     code_display_data = []
 
@@ -197,14 +202,15 @@ class KernelTests(TestCase):
             raise SkipTest
 
         for sample in self.code_display_data:
-            self.flush_channels()
-            reply, output_msgs = self.execute_helper(sample['code'])
+            with self.subTest(code=sample['code']):
+                self.flush_channels()
+                reply, output_msgs = self.execute_helper(sample['code'])
 
-            self.assertEqual(reply['content']['status'], 'ok')
+                self.assertEqual(reply['content']['status'], 'ok')
 
-            self.assertGreaterEqual(len(output_msgs), 1)
-            self.assertEqual(output_msgs[0]['msg_type'], 'display_data')
-            self.assertIn(sample['mime'], output_msgs[0]['content']['data'])
+                self.assertGreaterEqual(len(output_msgs), 1)
+                self.assertEqual(output_msgs[0]['msg_type'], 'display_data')
+                self.assertIn(sample['mime'], output_msgs[0]['content']['data'])
 
     def test_silent(self):
         self.flush_channels()

--- a/jupyter_kernel_test/__init__.py
+++ b/jupyter_kernel_test/__init__.py
@@ -174,6 +174,8 @@ class KernelTests(TestCase):
 
         reply, output_msgs = self.execute_helper(self.code_generate_error)
         self.assertEqual(reply['content']['status'], 'error')
+        self.assertEqual(len(output_msgs), 1)
+        self.assertEqual(output_msgs[0]['msg_type'], 'error')
 
     code_execute_result = []
 

--- a/jupyter_kernel_test/__init__.py
+++ b/jupyter_kernel_test/__init__.py
@@ -37,6 +37,7 @@ class KernelTests(TestCase):
                     validate_message(msg)
 
     language_name = ""
+    file_extension = ""
 
     def test_kernel_info(self):
         self.flush_channels()
@@ -48,6 +49,12 @@ class KernelTests(TestCase):
         if self.language_name:
             self.assertEqual(reply['content']['language_info']['name'],
                              self.language_name)
+        if self.file_extension:
+            self.assertEqual(reply['content']['language_info']['file_extension'],
+                             self.file_extension)
+            self.assertTrue(reply['content']['language_info']['file_extension'].startswith("."))
+
+
 
     def execute_helper(self, code, timeout=TIMEOUT,
                        silent=False, store_history=True):

--- a/jupyter_kernel_test/__init__.py
+++ b/jupyter_kernel_test/__init__.py
@@ -315,17 +315,14 @@ class KernelTests(TestCase):
         if not self.code_inspect_sample:
             raise SkipTest
 
-        for i in (0, 1):
-            with self.subTest(detail_level=i):
-                self.flush_channels()
-                msg_id = self.kc.inspect(self.code_inspect_sample,
-                                         detail_level=i)
-                reply = self.kc.get_shell_msg(timeout=TIMEOUT)
-                validate_message(reply, 'inspect_reply', msg_id)
+        self.flush_channels()
+        msg_id = self.kc.inspect(self.code_inspect_sample)
+        reply = self.kc.get_shell_msg(timeout=TIMEOUT)
+        validate_message(reply, 'inspect_reply', msg_id)
 
-                self.assertEqual(reply['content']['status'], 'ok')
-                self.assertTrue(reply['content']['found'])
-                self.assertGreaterEqual(len(reply['content']['data']), 1)
+        self.assertEqual(reply['content']['status'], 'ok')
+        self.assertTrue(reply['content']['found'])
+        self.assertGreaterEqual(len(reply['content']['data']), 1)
 
     code_clear_output = ""
 

--- a/jupyter_kernel_test/__init__.py
+++ b/jupyter_kernel_test/__init__.py
@@ -98,6 +98,21 @@ class KernelTests(TestCase):
         self.assertEqual(output_msgs[0]['content']['name'], 'stdout')
         self.assertIn('hello, world', output_msgs[0]['content']['text'])
 
+    code_stderr = ""
+
+    def test_execute_stderr(self):
+        if not self.code_stderr:
+            raise SkipTest
+
+        self.flush_channels()
+        reply, output_msgs = self.execute_helper(code=self.code_stderr)
+
+        self.assertEqual(reply['content']['status'], 'ok')
+
+        self.assertGreaterEqual(len(output_msgs), 1)
+        self.assertEqual(output_msgs[0]['msg_type'], 'stream')
+        self.assertEqual(output_msgs[0]['content']['name'], 'stderr')
+
     completion_samples = []
 
     def test_completion(self):

--- a/jupyter_kernel_test/__init__.py
+++ b/jupyter_kernel_test/__init__.py
@@ -299,11 +299,14 @@ class KernelTests(TestCase):
         if not self.code_inspect_sample:
             raise SkipTest
 
-        self.flush_channels()
-        msg_id = self.kc.inspect(self.code_inspect_sample)
-        reply = self.kc.get_shell_msg(timeout=TIMEOUT)
-        validate_message(reply, 'inspect_reply', msg_id)
+        for i in (0, 1):
+            with self.subTest(detail_level=i):
+                self.flush_channels()
+                msg_id = self.kc.inspect(self.code_inspect_sample,
+                                         detail_level=i)
+                reply = self.kc.get_shell_msg(timeout=TIMEOUT)
+                validate_message(reply, 'inspect_reply', msg_id)
 
-        self.assertEqual(reply['content']['status'], 'ok')
-        self.assertTrue(reply['content']['found'])
-        self.assertGreaterEqual(len(reply['content']['data']), 1)
+                self.assertEqual(reply['content']['status'], 'ok')
+                self.assertTrue(reply['content']['found'])
+                self.assertGreaterEqual(len(reply['content']['data']), 1)

--- a/jupyter_kernel_test/__init__.py
+++ b/jupyter_kernel_test/__init__.py
@@ -334,3 +334,17 @@ class KernelTests(TestCase):
                 self.assertEqual(reply['content']['status'], 'ok')
                 self.assertTrue(reply['content']['found'])
                 self.assertGreaterEqual(len(reply['content']['data']), 1)
+
+    code_clear_output = ""
+
+    def test_clear_output(self):
+        if not self.code_clear_output:
+            raise SkipTest
+
+        self.flush_channels()
+        reply, output_msgs = self.execute_helper(code=self.code_clear_output)
+
+        self.assertEqual(reply['content']['status'], 'ok')
+
+        self.assertGreaterEqual(len(output_msgs), 1)
+        self.assertEqual(output_msgs[0]['msg_type'], 'clear_output')

--- a/jupyter_kernel_test/__init__.py
+++ b/jupyter_kernel_test/__init__.py
@@ -224,6 +224,7 @@ class KernelTests(TestCase):
 
     # this should match one of the values in code_execute_result
     code_history_pattern = ""
+    supported_history_operations = ()
 
     def history_helper(self, execute_first, timeout=TIMEOUT, **histargs):
         self.flush_channels()
@@ -250,6 +251,8 @@ class KernelTests(TestCase):
         session = start = None
 
         with self.subTest(hist_access_type="tail"):
+            if 'tail' not in self.supported_history_operations:
+                raise SkipTest
             reply = self.history_helper(codes, output=False, raw=True,
                                         hist_access_type="tail", n=n)
             self.assertEqual(len(reply['content']['history']), n)
@@ -263,6 +266,8 @@ class KernelTests(TestCase):
                 self.assertEqual(len(reply['content']['history'][0][2]), 2)
 
         with self.subTest(hist_access_type="range"):
+            if 'range' not in self.supported_history_operations:
+                raise SkipTest
             if session is None:
                 raise SkipTest
             reply = self.history_helper(codes, output=False, raw=True,
@@ -275,6 +280,8 @@ class KernelTests(TestCase):
 
         with self.subTest(hist_access_type="search"):
             if not self.code_history_pattern:
+                raise SkipTest
+            if 'search' not in self.supported_history_operations:
                 raise SkipTest
 
             with self.subTest(subsearch="normal"):

--- a/jupyter_kernel_test/__init__.py
+++ b/jupyter_kernel_test/__init__.py
@@ -229,14 +229,6 @@ class KernelTests(TestCase):
                 self.assertEqual(output_msgs[0]['msg_type'], 'display_data')
                 self.assertIn(sample['mime'], output_msgs[0]['content']['data'])
 
-    def test_silent(self):
-        self.flush_channels()
-
-        reply, output_msgs = self.execute_helper("", silent=True)
-        self.assertEqual(reply['content']['status'], 'ok')
-        self.assertEqual(len(output_msgs), 0)
-        # test that execution_count has not been incremented?
-
     # this should match one of the values in code_execute_result
     code_history_pattern = ""
     supported_history_operations = ()

--- a/jupyter_kernel_test/messagespec.py
+++ b/jupyter_kernel_test/messagespec.py
@@ -133,6 +133,9 @@ class ExecuteResult(MimeBundle):
 class HistoryReply(Reference):
     history = List(List())
 
+class ClearOutput(Reference):
+    wait = Bool()
+
 
 """
 Specifications of `content` part of the reply messages.
@@ -151,6 +154,7 @@ references = {
     'stream' : Stream(),
     'display_data' : DisplayData(),
     'header' : RHeader(),
+    'clear_output' : ClearOutput(),
 }
 
 #validation specific to this version of the message specification

--- a/test_ipython.py
+++ b/test_ipython.py
@@ -25,7 +25,8 @@ class IRkernelTests(jkt.KernelTests):
     code_generate_error = "raise"
 
     code_execute_result = [
-        {'code': "1+1", 'result': "2"}
+        {'code': "1+2+3", 'result': "6"},
+        {'code': "[n*n for n in range(1, 4)]", 'result': "[1, 4, 9]"}
     ]
 
     code_display_data = [
@@ -34,6 +35,10 @@ class IRkernelTests(jkt.KernelTests):
         {'code': "from IPython.display import Math, display; display(Math('\\frac{1}{2}'))",
          'mime': "text/latex"}
     ]
+
+    code_history_pattern = "1?2*"
+
+    code_inspect_sample = "zip"
 
 if __name__ == '__main__':
     unittest.main()

--- a/test_ipython.py
+++ b/test_ipython.py
@@ -12,6 +12,8 @@ class IRkernelTests(jkt.KernelTests):
 
     code_hello_world = "print('hello, world')"
 
+    code_stderr = "import sys; print('test', file=sys.stderr)"
+
     completion_samples = [
         {
             'text': 'zi',

--- a/test_ipython.py
+++ b/test_ipython.py
@@ -39,6 +39,7 @@ class IRkernelTests(jkt.KernelTests):
     ]
 
     code_history_pattern = "1?2*"
+    supported_history_operations = ("tail", "range", "search")
 
     code_inspect_sample = "zip"
 

--- a/test_ipython.py
+++ b/test_ipython.py
@@ -45,5 +45,7 @@ class IRkernelTests(jkt.KernelTests):
 
     code_inspect_sample = "zip"
 
+    code_clear_output = "from IPython.display import clear_output; clear_output()"
+
 if __name__ == '__main__':
     unittest.main()

--- a/test_ipython.py
+++ b/test_ipython.py
@@ -8,6 +8,8 @@ class IRkernelTests(jkt.KernelTests):
 
     language_name = "python"
 
+    file_extension = ".py"
+
     code_hello_world = "print('hello, world')"
 
     completion_samples = [


### PR DESCRIPTION
More tests:
- Check `inspect_request` returns something
- Test execution with `silent=True` is silent
- Test several aspects of history: `tail`, `range` and `search` queries, and some of their options (`output`, `n`, `unique`). There are more combinations possible here, but I'm not actually sure what the correct semantics should be in some cases.
- Test for `file_extension` in `kernel_info_reply`
- Test that an error is reported in both `execute_reply` and an `error` message

In addition, some existing tests have had the `unittest.subTest()` context manager inserted where multiple aspects or code inputs were being tested to make the cause of errors clearer.
