### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -89,4 +89,4 @@ The following aspects of the messaging protocol are not explicitly tested:
 - Execution: combinations of ``silent``, ``store_history`` and ``stop_on_error``
 
 .. _Jupyter: http://jupyter.org
-.. _Jupyter Messaging Protocol: http://jupyter-client.readthedocs.org/en/latest/messaging.html
+.. _Jupyter Messaging Protocol: https://jupyter-client.readthedocs.io/en/latest/messaging.html


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
