### PR TITLE
Fix import issue with pytest

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,9 +40,6 @@ Example
     import unittest
     import jupyter_kernel_test
 
-    # *Don't* do 'from jupyter_kernel_test import KernelTests'
-    # If you do, it will try to run the base class as tests, which will fail.   
-
     class MyKernelTests(jupyter_kernel_test.KernelTests):
         # Required --------------------------------------
 

--- a/jupyter_kernel_test/__init__.py
+++ b/jupyter_kernel_test/__init__.py
@@ -28,6 +28,9 @@ class KernelTests(TestCase):
 
     @classmethod
     def setUpClass(cls):
+        if cls is KernelTests:
+            raise SkipTest
+
         conn_info, km = cls.launch_kernel()
         cls.kc = BlockingKernelClient(conn_info, manager=km)
         cls.kc.wait_for_ready(timeout=TIMEOUT)

--- a/jupyter_kernel_test/__init__.py
+++ b/jupyter_kernel_test/__init__.py
@@ -28,6 +28,8 @@ class KernelTests(TestCase):
 
     @classmethod
     def setUpClass(cls):
+        # Skip tests if it's an instance of KernelTests
+        # See https://github.com/jupyter/jupyter_kernel_test/issues/7
         if cls is KernelTests:
             raise SkipTest
 


### PR DESCRIPTION
Fixes #7. At first I thought that just renaming the class would work, but I think that `pytest` (or `unittest`) looks for classes inheriting from `unittest.TestCase` in the scope. Skipping the test if it's an instance of `KernelTests` fixes the issue without changing user code. 