### PR TITLE
Fix custom test example in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -74,9 +74,9 @@ Example
         # jupyter_kernel_test adds in the future.
         def test_mykernel_stderr(self):
             reply, output_msgs = self.execute_helper(code='print_err "oops"')
-            self.assertEqual(output_msgs[0].header['msg_type'], 'stream')
-            self.assertEqual(output_msgs[0].content['name'], 'stderr')
-            self.assertEqual(output_msgs[0].content['text'], 'oops\n')
+            self.assertEqual(output_msgs[0]['header']['msg_type'], 'stream')
+            self.assertEqual(output_msgs[0]['content']['name'], 'stderr')
+            self.assertEqual(output_msgs[0]['content']['text'], 'oops\n')
 
     if __name__ == '__main__':
         unittest.main()

--- a/README.rst
+++ b/README.rst
@@ -73,6 +73,7 @@ Example
         # in the method name, to avoid clashing with any tests that
         # jupyter_kernel_test adds in the future.
         def test_mykernel_stderr(self):
+            self.flush_channels()
             reply, output_msgs = self.execute_helper(code='print_err "oops"')
             self.assertEqual(output_msgs[0]['header']['msg_type'], 'stream')
             self.assertEqual(output_msgs[0]['content']['name'], 'stderr')


### PR DESCRIPTION
The example in the README doesn't work. With pytest it gives `AttributeError: 'dict' object has no attribute 'header'`. It has to be changed to dict indexing.

Edit:
Additionally, I kept getting errors of the following form when using my personal kernel:
```
/Users/kylebarron/anaconda/lib/python3.6/site-packages/jupyter_kernel_test/__init__.py:67: in execute_helper
    validate_message(busy_msg, 'status', msg_id)
/Users/kylebarron/anaconda/lib/python3.6/site-packages/jupyter_kernel_test/messagespec.py:172: in validate_message
    nt.assert_equal(msg['parent_header']['msg_id'], parent)
E   AssertionError: '9eb078a0-9ab483c3e379f46da1ce7183' != 'fc076ab9-a5a686821ebdcc3d9056a72b'
E   - 9eb078a0-9ab483c3e379f46da1ce7183
E   + fc076ab9-a5a686821ebdcc3d9056a72b
```

These were fixed by adding `self.flush_channels()`, and each of the test functions in [`__init__.py`](https://github.com/jupyter/jupyter_kernel_test/blob/0.3/jupyter_kernel_test/__init__.py) precedes `self.execute_helper` with `self.flush_channels()`, so this PR also includes that in the example.