### PR TITLE
Automated Changelog Entry for 0.4.0 on master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.4.0
+
+([Full Changelog](https://github.com/jupyter/jupyter_kernel_test/compare/0.3...687e6f83af9cecae832c4ad8f79291322def23e5))
+
+### Enhancements made
+
+- Use jsonschema to validate messages [#37](https://github.com/jupyter/jupyter_kernel_test/pull/37) ([@takluyver](https://github.com/takluyver))
+
+### Maintenance and upkeep improvements
+
+- Prep for jupyter releaser usage [#59](https://github.com/jupyter/jupyter_kernel_test/pull/59) ([@blink1073](https://github.com/blink1073))
+- Test IR Kernel and Clean Up [#58](https://github.com/jupyter/jupyter_kernel_test/pull/58) ([@blink1073](https://github.com/blink1073))
+- Update for Jupyter Client 7 and GitHub Actions [#57](https://github.com/jupyter/jupyter_kernel_test/pull/57) ([@blink1073](https://github.com/blink1073))
+- Fix import issue with pytest [#46](https://github.com/jupyter/jupyter_kernel_test/pull/46) ([@martinRenou](https://github.com/martinRenou))
+- Use new kernel management modules [#41](https://github.com/jupyter/jupyter_kernel_test/pull/41) ([@takluyver](https://github.com/takluyver))
+- Replace COPYING.md with LICENCE file [#34](https://github.com/jupyter/jupyter_kernel_test/pull/34) ([@tgb417](https://github.com/tgb417))
+
+- Fix custom test example in README [#49](https://github.com/jupyter/jupyter_kernel_test/pull/49) ([@kylebarron](https://github.com/kylebarron))
+- Fix readme [#45](https://github.com/jupyter/jupyter_kernel_test/pull/45) ([@martinRenou](https://github.com/martinRenou))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyter/jupyter_kernel_test/graphs/contributors?from=2017-04-28&to=2021-11-30&type=c))
+
+[@blink1073](https://github.com/search?q=repo%3Ajupyter%2Fjupyter_kernel_test+involves%3Ablink1073+updated%3A2017-04-28..2021-11-30&type=Issues) | [@kylebarron](https://github.com/search?q=repo%3Ajupyter%2Fjupyter_kernel_test+involves%3Akylebarron+updated%3A2017-04-28..2021-11-30&type=Issues) | [@martinRenou](https://github.com/search?q=repo%3Ajupyter%2Fjupyter_kernel_test+involves%3AmartinRenou+updated%3A2017-04-28..2021-11-30&type=Issues) | [@SylvainCorlay](https://github.com/search?q=repo%3Ajupyter%2Fjupyter_kernel_test+involves%3ASylvainCorlay+updated%3A2017-04-28..2021-11-30&type=Issues) | [@takluyver](https://github.com/search?q=repo%3Ajupyter%2Fjupyter_kernel_test+involves%3Atakluyver+updated%3A2017-04-28..2021-11-30&type=Issues) | [@tgb417](https://github.com/search?q=repo%3Ajupyter%2Fjupyter_kernel_test+involves%3Atgb417+updated%3A2017-04-28..2021-11-30&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 0.3
 
 ([Full Changelog](https://github.com/jupyter/jupyter_kernel_test/compare/7283c8c...309feed))
@@ -18,5 +46,3 @@
 ([GitHub contributors page for this release](https://github.com/jupyter/jupyter_kernel_test/graphs/contributors?from=2016-06-13&to=2017-04-28&type=c))
 
 [@adamchainz](https://github.com/search?q=repo%3Ajupyter%2Fjupyter_kernel_test+involves%3Aadamchainz+updated%3A2016-06-13..2017-04-28&type=Issues) | [@mariusvniekerk](https://github.com/search?q=repo%3Ajupyter%2Fjupyter_kernel_test+involves%3Amariusvniekerk+updated%3A2016-06-13..2017-04-28&type=Issues) | [@maveme](https://github.com/search?q=repo%3Ajupyter%2Fjupyter_kernel_test+involves%3Amaveme+updated%3A2016-06-13..2017-04-28&type=Issues) | [@shzhng](https://github.com/search?q=repo%3Ajupyter%2Fjupyter_kernel_test+involves%3Ashzhng+updated%3A2016-06-13..2017-04-28&type=Issues) | [@takluyver](https://github.com/search?q=repo%3Ajupyter%2Fjupyter_kernel_test+involves%3Atakluyver+updated%3A2016-06-13..2017-04-28&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->


### PR DESCRIPTION
Automated Changelog Entry for 0.4.0 on master

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyter/jupyter_kernel_test  |
| Branch  | master  |
| Version Spec | 0.4.0 |
| Since | 0.3 |