### PR TITLE
Add more robustness

### DIFF
--- a/jupyter_kernel_test/__init__.py
+++ b/jupyter_kernel_test/__init__.py
@@ -361,8 +361,13 @@ class KernelTests(TestCase):
 
         self.flush_channels()
         reply, output_msgs = self.execute_helper(code=self.code_clear_output)
-
         self.assertEqual(reply['content']['status'], 'ok')
-
         self.assertGreaterEqual(len(output_msgs), 1)
-        self.assertEqual(output_msgs[0]['msg_type'], 'clear_output')
+
+        found = False
+        for msg in output_msgs:
+            if msg['msg_type'] == 'clear_output':
+                found = True
+            else:
+                continue
+        assert found, 'clear_output message not found'

--- a/jupyter_kernel_test/msgspec_v5.py
+++ b/jupyter_kernel_test/msgspec_v5.py
@@ -44,7 +44,7 @@ msg_schema = {
     "type": "object",
     "properties": {
         "header": header_part,
-        "parent_header": header_part,
+        "parent_header": {"type": "object"},
         "metadata": {"type": "object"},
         "content": {"type": "object"},  # Checked separately
         "buffers": {"type": "array"}
@@ -117,7 +117,7 @@ def validate_message(msg, msg_type=None, parent_id=None):
             raise ValidationError("Unexpected keys in header: {}".format(unx_header))
 
     # Check the parent id
-    if parent_id and msg['parent_header']['msg_id'] != parent_id:
+    if 'reply' in msg_type and parent_id and msg['parent_header']['msg_id'] != parent_id:
         raise ValidationError("Parent header does not match expected")
 
     if msg_type in reply_msgs_using_status:


### PR DESCRIPTION
- Allow `clear_output` to be any of the returned messages
- Allow the parent header to be empty for non-reply messages